### PR TITLE
Add swiftGuard (Physical Access Security, macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 29. [FSMonitor](http://fsmonitor.com/) - Monitor all changes in the file system.
 30. [Pareto Security](https://github.com/paretoSecurity/pareto-mac/) - A MenuBar app to automatically audit your Mac for basic security hygiene.
 31. [Mana Security](https://github.com/manasecurity/mana-security-app) - Vulnerability Management app for individuals. It helps to keep macOS and installed applications updated.
+32. [swiftGuard](https://github.com/Lennolium/swiftGuard) - Lightweight App that safeguards your System's USB Ports from any Unauthorized Access and performs various Counter-Measures.
 
 ## iOS Security
 


### PR DESCRIPTION
I added the Anti-Forensic Application 'swiftGuard' to the category 'macOS Security'.

### Overview
It's an anti-forensic macOS tray application designed to safeguard your system or server by monitoring USB ports. It ensures your device's operational security by automatically initiating either a system shutdown or hibernation if an unauthorized device connects or a connected device is unplugged. It offers the flexibility to whitelist designated devices, to select an action to be executed and to set a countdown timer, allowing to disarm the shutdown process. It's a revival of the well-known [usbkill project](https://github.com/hephaest0s/usbkill) by hephaestos, but with a Graphical User Interface and added functionality.

[swiftGuard on Github](https://github.com/Lennolium/swiftGuard)

### Why?

For non-technical user, using the original usbkill command line tool (see above) is far too difficult. This is the reason for swiftGuard: It offers a nice, clean and intuitive Interface with some additional features, whitelisting and an active development (unlike usbkill, which seems abandoned).

### Screenshots
![Interface](https://github.com/Lennolium/swiftGuard/raw/main/img/screenshots/screenshots.png)


>__Disclaimer:__
>I'm an computer science student and developed this app by myself. I did not want to offensively spam/advertise my work here. _I really think_, it would improve this curated list and help others. 
