### PR TITLE
Add Lockpaw to macOS Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 1. [Pareto Security](https://github.com/paretoSecurity/pareto-mac/) - A MenuBar app to automatically audit your Mac for basic security hygiene.
 1. [swiftGuard](https://github.com/Lennolium/swiftGuard) - Lightweight App that safeguards your System's USB Ports from any Unauthorized Access and performs various countermeasures.
 1. [Malimite](https://github.com/LaurieWired/Malimite) - iOS and macOS Decompiler
+1. [Lockpaw](https://github.com/sorkila/lockpaw) - macOS menu bar screen guard that locks and unlocks your display with a hotkey. Open source, no telemetry.
 1. ~~[MIDAS](https://github.com/etsy/MIDAS) - macOS Intrusion Detection Analysis System.~~ Abandoned.
 1. ~~[Mana Security](https://github.com/manasecurity/mana-security-app) - Vulnerability Management app for individuals. It helps to keep macOS and installed applications updated.~~ Looks abandoned.
 


### PR DESCRIPTION
[Lockpaw](https://github.com/sorkila/lockpaw) is an open-source macOS menu bar screen guard. Lock and unlock your display with a global hotkey. Built with Swift, MIT licensed, no telemetry.

- 47+ GitHub stars
- Available via Homebrew (`brew tap sorkila/lockpaw && brew install --cask lockpaw`)
- Sparkle auto-updates with EdDSA signing