### PR TITLE
Add fort - macOS endpoint security CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@
 1. [TaskExplorer](https://objective-see.com/products/taskexplorer.html) - Explore all processes running on your Mac with TaskExplorer.
 1. [What's Your Sign?](https://objective-see.com/products/whatsyoursign.html) - Adds menu item to Finder.app to display the cryptographic signing information for any file.
 1. [FSMonitor](http://fsmonitor.com/) - Monitor all changes in the file system.
-1. [fort](https://github.com/djadmin/fort) - CLI to audit, fix, and prove macOS endpoint security. 15 checks, auto-remediation, SOC 2 evidence report. Single binary, no agent.
 1. [Pareto Security](https://github.com/paretoSecurity/pareto-mac/) - A MenuBar app to automatically audit your Mac for basic security hygiene.
 1. [swiftGuard](https://github.com/Lennolium/swiftGuard) - Lightweight App that safeguards your System's USB Ports from any Unauthorized Access and performs various countermeasures.
 1. [Malimite](https://github.com/LaurieWired/Malimite) - iOS and macOS Decompiler
 1. [Lockpaw](https://github.com/sorkila/lockpaw) - macOS menu bar screen guard that locks and unlocks your display with a hotkey. Open source, no telemetry.
+1. [fort](https://github.com/djadmin/fort) - CLI to audit, fix, and prove macOS endpoint security. 15 checks, auto-remediation, SOC 2 evidence report. Single binary, no agent.
 1. ~~[MIDAS](https://github.com/etsy/MIDAS) - macOS Intrusion Detection Analysis System.~~ Abandoned.
 1. ~~[Mana Security](https://github.com/manasecurity/mana-security-app) - Vulnerability Management app for individuals. It helps to keep macOS and installed applications updated.~~ Looks abandoned.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 1. [TaskExplorer](https://objective-see.com/products/taskexplorer.html) - Explore all processes running on your Mac with TaskExplorer.
 1. [What's Your Sign?](https://objective-see.com/products/whatsyoursign.html) - Adds menu item to Finder.app to display the cryptographic signing information for any file.
 1. [FSMonitor](http://fsmonitor.com/) - Monitor all changes in the file system.
+1. [fort](https://github.com/djadmin/fort) - CLI to audit, fix, and prove macOS endpoint security. 15 checks, auto-remediation, SOC 2 evidence report. Single binary, no agent.
 1. [Pareto Security](https://github.com/paretoSecurity/pareto-mac/) - A MenuBar app to automatically audit your Mac for basic security hygiene.
 1. [swiftGuard](https://github.com/Lennolium/swiftGuard) - Lightweight App that safeguards your System's USB Ports from any Unauthorized Access and performs various countermeasures.
 1. [Malimite](https://github.com/LaurieWired/Malimite) - iOS and macOS Decompiler


### PR DESCRIPTION
Adding fort, an open-source macOS endpoint security CLI.

**URL:** https://github.com/djadmin/fort

fort checks 15 macOS security settings (disk encryption, firewall, screen lock, Gatekeeper, SIP, SSH, local admin rights, AirDrop, sharing services, OS updates, EDR presence), auto-remediates fixable ones, and generates an HTML evidence report for SOC 2 audits.

- Single Go binary, no agent, no MDM
- MIT licensed
- v0.2.0 released May 2026
- Placed in macOS Security section, before Pareto Security (alphabetical)